### PR TITLE
Actualiza enlace a la guía oficial

### DIFF
--- a/DOCUMENTACION.md
+++ b/DOCUMENTACION.md
@@ -60,7 +60,7 @@ pago.pay({
     // hacer algo con la respuesta.
 });
 ```
-> **Importante**: Se debe solicitar las llaves `keyId` y `publicKeyId` en la página de Instapago. [Aquí](http://instapago.com/wp-content/uploads/2015/10/Guia-Integracion-API-Instapago-1.6.pdf) puedes encontrar mayor información.
+> **Importante**: Se debe solicitar las llaves `keyId` y `publicKeyId` en la página de Instapago. [Aquí](http://instapago.com/wp-content/uploads/2016/02/Guia-Integracion-API-Instapago-1.6.pdf) puedes encontrar mayor información.
 Además, se recomienda definirlas como variables de entorno para mayor seguridad.
 
 ## métodos del API


### PR DESCRIPTION
El enlance a la guía oficial para integrar el API de Instapago con una aplicación estaba roto.
