### PR TITLE
Repara bug en las respuestas retornadas por los callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > Todos los cambios significativos en la librería serán registrados en éste documento.
 
+## [0.4.2](https://github.com/abr4xas/node-instapago/tree/v0.4.2) - 2016-05-16
+
+### Reparado
+
+* Se solucionó un *bug* que retornaba los resultados correctos cuando se suponía que debía retornar los errores.
+
 ## [0.4.1](https://github.com/abr4xas/node-instapago/tree/v0.4.1) - 2016-04-21
 
 ### Cambiado

--- a/instapago.js
+++ b/instapago.js
@@ -140,7 +140,7 @@ function callInstapago(config, callback) {
       return callback(error);
     }
 
-    if (response.statusCode !== 201) {
+    if (response.statusCode !== 200) {
       return callback(body);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instapago",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Librería Instapago para Node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Los callbacks retornaban error cuando debían retornar los resultados correctos; la lógica para retornar las respuestas estaba invertida.
